### PR TITLE
git, p5-mac-systemdirectory : fails to build when the libuuid port is active

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           legacysupport   1.1
 PortGroup           perl5           1.0
+PortGroup           conflicts_build 1.0
 
 legacysupport.newest_darwin_requires_legacy 11
 
@@ -111,6 +112,8 @@ perl5.conflict_variants yes
 perl5.branches          5.28 5.30 5.32 5.34
 perl5.default_branch    5.34
 perl5.create_variants   ${perl5.branches}
+
+conflicts_build     libuuid
 
 depends_build-append \
                     port:gettext

--- a/perl/p5-mac-systemdirectory/Portfile
+++ b/perl/p5-mac-systemdirectory/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
+PortGroup           conflicts_build 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Mac-SystemDirectory 0.14
@@ -17,6 +18,8 @@ checksums           rmd160  5b9b35aad2ae4d3c326b125cd170141c001fdabd \
                     size    34226
 
 platforms           darwin
+
+conflicts_build     libuuid
 
 if {${perl5.major} != ""} {
     patchfiles      patch-macos-10.10+.diff


### PR DESCRIPTION
#### Description

```
added :
PortGroup           conflicts_build 1.0
conflicts_build     libuuid

On branch libuuidconflicts
Changes to be committed:
	modified:   devel/git/Portfile
	modified:   perl/p5-mac-systemdirectory/Portfile
```
closes: https://trac.macports.org/ticket/72200
closes: https://trac.macports.org/ticket/63365

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
